### PR TITLE
Pin github workflows to a commit hash instead of version tag for security purpose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: |
           npm install
           npm run typecheck


### PR DESCRIPTION

This PR pins Github workflows to a specific commit hash instead of version tag, for security purpose.

Previously, there was a security incident where a Github action we use got compromised to expose our secrets. ref https://dev.notion.so/notion/sec-ir-20250315-tj-actions-1b7b35e6e67f8105b1e9e5b1a46c6515

By pinning Github workflows to a specific commit hash, we should be able to restrict deployment of potentially compromised Github actions in the future. If you have any questions, please reach out to #sec-team-appsec.

Note: If you ever need to manually look up the commit hash for a given action version (tag), you can run:

    git ls-remote https://github.com/<owner>/<repo>.git <tag>

Replace `<owner>`, `<repo>`, and `<tag>` with the appropriate values (for example, `actions/checkout` and `v3`). The output will show the commit SHA corresponding to the tag. Use that SHA in your workflow file, e.g.:

    uses: actions/checkout@<sha> # <tag version>
